### PR TITLE
Clock removed ZoneId references

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,11 @@ Serialization is not supported, and all support classes and forms including magi
 
 A goal is to leave source in their original package `org.threeten.bp` and correct this in the distributed zip containing 
 the javascript. Another goal is to support executing as many as possible of the original backport tests.
+
+
+## JRE Differences
+
+### Clock
+
+- Clock.systemUTC() & Clock.systemDefaultZone() are equivalent, both without a ZoneId.
+- Clock.getZone() is unavailable.

--- a/src/main/java/org/threeten/bp/Clock.java
+++ b/src/main/java/org/threeten/bp/Clock.java
@@ -31,13 +31,14 @@
  */
 package org.threeten.bp;
 
-import static org.threeten.bp.LocalTime.NANOS_PER_MINUTE;
-import static org.threeten.bp.LocalTime.NANOS_PER_SECOND;
+import javaemul.internal.annotations.GwtIncompatible;
+import org.threeten.bp.jdk8.Jdk8Methods;
 
 import java.io.Serializable;
 import java.util.TimeZone;
 
-import org.threeten.bp.jdk8.Jdk8Methods;
+import static org.threeten.bp.LocalTime.NANOS_PER_MINUTE;
+import static org.threeten.bp.LocalTime.NANOS_PER_SECOND;
 
 /**
  * A clock providing access to the current instant, date and time using a time-zone.
@@ -111,7 +112,8 @@ public abstract class Clock {
      * @return a clock that uses the best available system clock in the UTC zone, not null
      */
     public static Clock systemUTC() {
-        return new SystemClock(ZoneOffset.UTC);
+        //return new SystemClock(ZoneOffset.UTC);
+        return new SystemClock();
     }
 
     /**
@@ -134,7 +136,8 @@ public abstract class Clock {
      * @see ZoneId#systemDefault()
      */
     public static Clock systemDefaultZone() {
-        return new SystemClock(ZoneId.systemDefault());
+        //return new SystemClock(ZoneId.systemDefault());
+        return new SystemClock();
     }
 
     /**
@@ -152,6 +155,7 @@ public abstract class Clock {
      * @param zone  the time-zone to use to convert the instant to date-time, not null
      * @return a clock that uses the best available system clock in the specified zone, not null
      */
+    @GwtIncompatible
     public static Clock system(ZoneId zone) {
         Jdk8Methods.requireNonNull(zone, "zone");
         return new SystemClock(zone);
@@ -177,6 +181,7 @@ public abstract class Clock {
      * @param zone  the time-zone to use to convert the instant to date-time, not null
      * @return a clock that ticks in whole seconds using the specified zone, not null
      */
+    @GwtIncompatible
     public static Clock tickSeconds(ZoneId zone) {
         return new TickClock(system(zone), NANOS_PER_SECOND);
     }
@@ -200,6 +205,7 @@ public abstract class Clock {
      * @param zone  the time-zone to use to convert the instant to date-time, not null
      * @return a clock that ticks in whole minutes using the specified zone, not null
      */
+    @GwtIncompatible
     public static Clock tickMinutes(ZoneId zone) {
         return new TickClock(system(zone), NANOS_PER_MINUTE);
     }
@@ -270,6 +276,7 @@ public abstract class Clock {
      * @param zone  the time-zone to use to convert the instant to date-time, not null
      * @return a clock that always returns the same instant, not null
      */
+    @GwtIncompatible
     public static Clock fixed(Instant fixedInstant, ZoneId zone) {
         Jdk8Methods.requireNonNull(fixedInstant, "fixedInstant");
         Jdk8Methods.requireNonNull(zone, "zone");
@@ -296,6 +303,7 @@ public abstract class Clock {
      * @param offsetDuration  the duration to add, not null
      * @return a clock based on the base clock with the duration added, not null
      */
+    @GwtIncompatible
     public static Clock offset(Clock baseClock, Duration offsetDuration) {
         Jdk8Methods.requireNonNull(baseClock, "baseClock");
         Jdk8Methods.requireNonNull(offsetDuration, "offsetDuration");
@@ -321,6 +329,7 @@ public abstract class Clock {
      *
      * @return the time-zone being used to interpret instants, not null
      */
+    @GwtIncompatible
     public abstract ZoneId getZone();
 
     /**
@@ -397,22 +406,40 @@ public abstract class Clock {
      * {@link System#currentTimeMillis()}.
      */
     static final class SystemClock extends Clock implements Serializable {
+        @GwtIncompatible
         private static final long serialVersionUID = 6740630888130243051L;
-        private final ZoneId zone;
+
+        //private final ZoneId zone;
+
+        SystemClock() {
+        }
 
         SystemClock(ZoneId zone) {
-            this.zone = zone;
+            //this.zone = zone;
+            throw new UnsupportedOperationException();
         }
+//        @Override
+//        public ZoneId getZone() {
+//            return zone;
+//        }
+
+        @GwtIncompatible
         @Override
         public ZoneId getZone() {
-            return zone;
+            throw new UnsupportedOperationException();
         }
+//        @Override
+//        public Clock withZone(ZoneId zone) {
+//            if (zone.equals(this.zone)) {  // intentional NPE
+//                return this;
+//            }
+//            return new SystemClock(zone);
+//        }
+
+        @GwtIncompatible
         @Override
         public Clock withZone(ZoneId zone) {
-            if (zone.equals(this.zone)) {  // intentional NPE
-                return this;
-            }
-            return new SystemClock(zone);
+            throw new UnsupportedOperationException();
         }
         @Override
         public long millis() {
@@ -424,18 +451,20 @@ public abstract class Clock {
         }
         @Override
         public boolean equals(Object obj) {
-            if (obj instanceof SystemClock) {
-                return zone.equals(((SystemClock) obj).zone);
-            }
-            return false;
+//            if (obj instanceof SystemClock) {
+//                //return zone.equals(((SystemClock) obj).zone);
+//            }
+//            return false;
+            return obj instanceof SystemClock;
         }
         @Override
         public int hashCode() {
-            return zone.hashCode() + 1;
+            //return zone.hashCode() + 1;
+            return 1;
         }
         @Override
         public String toString() {
-            return "SystemClock[" + zone + "]";
+            return "SystemClock";
         }
     }
 
@@ -444,6 +473,7 @@ public abstract class Clock {
      * Implementation of a clock that always returns the same instant.
      * This is typically used for testing.
      */
+    @GwtIncompatible
     static final class FixedClock extends Clock implements Serializable {
        private static final long serialVersionUID = 7430389292664866958L;
         private final Instant instant;
@@ -453,6 +483,7 @@ public abstract class Clock {
             this.instant = fixedInstant;
             this.zone = zone;
         }
+        @GwtIncompatible
         @Override
         public ZoneId getZone() {
             return zone;
@@ -494,6 +525,7 @@ public abstract class Clock {
     /**
      * Implementation of a clock that adds an offset to an underlying clock.
      */
+    @GwtIncompatible
     static final class OffsetClock extends Clock implements Serializable {
        private static final long serialVersionUID = 2007484719125426256L;
         private final Clock baseClock;
@@ -503,6 +535,7 @@ public abstract class Clock {
             this.baseClock = baseClock;
             this.offset = offset;
         }
+        @GwtIncompatible
         @Override
         public ZoneId getZone() {
             return baseClock.getZone();
@@ -545,6 +578,7 @@ public abstract class Clock {
      * Implementation of a clock that adds an offset to an underlying clock.
      */
     static final class TickClock extends Clock implements Serializable {
+        @GwtIncompatible
         private static final long serialVersionUID = 6504659149906368850L;
         private final Clock baseClock;
         private final long tickNanos;
@@ -553,6 +587,7 @@ public abstract class Clock {
             this.baseClock = baseClock;
             this.tickNanos = tickNanos;
         }
+        @GwtIncompatible
         @Override
         public ZoneId getZone() {
             return baseClock.getZone();

--- a/src/main/java/org/threeten/bp/LocalDate.java
+++ b/src/main/java/org/threeten/bp/LocalDate.java
@@ -194,8 +194,10 @@ public final class LocalDate
     public static LocalDate now(Clock clock) {
         Jdk8Methods.requireNonNull(clock, "clock");
         final Instant now = clock.instant();  // called once
-        ZoneOffset offset = clock.getZone().getRules().getOffset(now);
-        long epochSec = now.getEpochSecond() + offset.getTotalSeconds();  // overflow caught later
+//        ZoneOffset offset = clock.getZone().getRules().getOffset(now);
+//        long epochSec = now.getEpochSecond() + offset.getTotalSeconds();  // overflow caught later
+        final long epochSec = now.getEpochSecond();
+
         long epochDay = Jdk8Methods.floorDiv(epochSec, SECONDS_PER_DAY);
         return LocalDate.ofEpochDay(epochDay);
     }

--- a/src/main/java/org/threeten/bp/LocalDateTime.java
+++ b/src/main/java/org/threeten/bp/LocalDateTime.java
@@ -48,6 +48,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.ChronoLocalDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
@@ -181,8 +182,9 @@ public final class LocalDateTime
     public static LocalDateTime now(Clock clock) {
         Jdk8Methods.requireNonNull(clock, "clock");
         final Instant now = clock.instant();  // called once
-        ZoneOffset offset = clock.getZone().getRules().getOffset(now);
-        return ofEpochSecond(now.getEpochSecond(), now.getNano(), offset);
+        //ZoneOffset offset = clock.getZone().getRules().getOffset(now);
+        //return ofEpochSecond(now.getEpochSecond(), now.getNano(), offset);
+        return ofEpochSecond(now.getEpochSecond(), now.getNano());
     }
 
     //-----------------------------------------------------------------------
@@ -350,6 +352,7 @@ public final class LocalDateTime
      * @return the local date-time, not null
      * @throws DateTimeException if the result exceeds the supported range
      */
+    @GwtIncompatible
     public static LocalDateTime ofInstant(Instant instant, ZoneId zone) {
         Jdk8Methods.requireNonNull(instant, "instant");
         Jdk8Methods.requireNonNull(zone, "zone");
@@ -372,9 +375,19 @@ public final class LocalDateTime
      * @return the local date-time, not null
      * @throws DateTimeException if the result exceeds the supported range
      */
+    @GwtIncompatible
     public static LocalDateTime ofEpochSecond(long epochSecond, int nanoOfSecond, ZoneOffset offset) {
         Jdk8Methods.requireNonNull(offset, "offset");
         long localSecond = epochSecond + offset.getTotalSeconds();  // overflow caught later
+        long localEpochDay = Jdk8Methods.floorDiv(localSecond, SECONDS_PER_DAY);
+        int secsOfDay = Jdk8Methods.floorMod(localSecond, SECONDS_PER_DAY);
+        LocalDate date = LocalDate.ofEpochDay(localEpochDay);
+        LocalTime time = LocalTime.ofSecondOfDay(secsOfDay, nanoOfSecond);
+        return new LocalDateTime(date, time);
+    }
+
+    private static LocalDateTime ofEpochSecond(long epochSecond, int nanoOfSecond) {
+        long localSecond = epochSecond;  // overflow caught later
         long localEpochDay = Jdk8Methods.floorDiv(localSecond, SECONDS_PER_DAY);
         int secsOfDay = Jdk8Methods.floorMod(localSecond, SECONDS_PER_DAY);
         LocalDate date = LocalDate.ofEpochDay(localEpochDay);

--- a/src/main/java/org/threeten/bp/LocalTime.java
+++ b/src/main/java/org/threeten/bp/LocalTime.java
@@ -247,9 +247,10 @@ public final class LocalTime
         Jdk8Methods.requireNonNull(clock, "clock");
         // inline OffsetTime factory to avoid creating object and InstantProvider checks
         final Instant now = clock.instant();  // called once
-        ZoneOffset offset = clock.getZone().getRules().getOffset(now);
+//        ZoneOffset offset = clock.getZone().getRules().getOffset(now);
+
         long secsOfDay = now.getEpochSecond() % SECONDS_PER_DAY;
-        secsOfDay = (secsOfDay + offset.getTotalSeconds()) % SECONDS_PER_DAY;
+//        secsOfDay = (secsOfDay + offset.getTotalSeconds()) % SECONDS_PER_DAY;
         if (secsOfDay < 0) {
             secsOfDay += SECONDS_PER_DAY;
         }

--- a/src/main/java/org/threeten/bp/chrono/HijrahDate.java
+++ b/src/main/java/org/threeten/bp/chrono/HijrahDate.java
@@ -517,20 +517,23 @@ public final class HijrahDate
     private static void checkValidYearOfEra(int yearOfEra) {
          if (yearOfEra < MIN_VALUE_OF_ERA  ||
                  yearOfEra > MAX_VALUE_OF_ERA) {
-             throw new DateTimeException("Invalid year of Hijrah Era");
+//             throw new DateTimeException("Invalid year of Hijrah Era");
+             throw new DateTimeException("Invalid year " + yearOfEra + " of Hijrah Era");
          }
     }
 
     private static void checkValidDayOfYear(int dayOfYear) {
          if (dayOfYear < 1  ||
                  dayOfYear > getMaximumDayOfYear()) {
-             throw new DateTimeException("Invalid day of year of Hijrah date");
+//             throw new DateTimeException("Invalid day of year of Hijrah date");
+             throw new DateTimeException("Invalid day " + dayOfYear + " of year of Hijrah date");
          }
     }
 
     private static void checkValidMonth(int month) {
          if (month < 1 || month > 12) {
-             throw new DateTimeException("Invalid month of Hijrah date");
+//             throw new DateTimeException("Invalid month of Hijrah date");
+             throw new DateTimeException("Invalid month " + month + " of Hijrah date");
          }
     }
 

--- a/src/test/java/org/threeten/bp/TestClock_Offset.java
+++ b/src/test/java/org/threeten/bp/TestClock_Offset.java
@@ -44,14 +44,15 @@ import org.testng.annotations.Test;
 @Test
 public class TestClock_Offset extends AbstractTest {
 
-    private static final ZoneId MOSCOW = ZoneId.of("Europe/Moscow");
+    //private static final ZoneId MOSCOW = ZoneId.of("Europe/Moscow");
     private static final ZoneId PARIS = ZoneId.of("Europe/Paris");
     private static final Instant INSTANT = LocalDateTime.of(2008, 6, 30, 11, 30, 10, 500).atZone(ZoneOffset.ofHours(2)).toInstant();
     private static final Duration OFFSET = Duration.ofSeconds(2);
 
     //-----------------------------------------------------------------------
     public void test_isSerializable() throws IOException, ClassNotFoundException {
-        assertSerializable(Clock.offset(Clock.system(PARIS), OFFSET));
+        //assertSerializable(Clock.offset(Clock.system(PARIS), OFFSET));
+        assertSerializable(Clock.offset(Clock.systemDefaultZone(), OFFSET));
     }
 
     //-----------------------------------------------------------------------
@@ -62,7 +63,8 @@ public class TestClock_Offset extends AbstractTest {
     }
 
     public void test_offset_ClockDuration_zeroDuration() {
-        Clock underlying = Clock.system(PARIS);
+        //Clock underlying = Clock.system(PARIS);
+        Clock underlying = Clock.systemUTC();
         Clock test = Clock.offset(underlying, Duration.ZERO);
         assertSame(test, underlying);  // spec says same
     }
@@ -78,38 +80,40 @@ public class TestClock_Offset extends AbstractTest {
     }
 
     //-------------------------------------------------------------------------
-    public void test_withZone() {
-        Clock test = Clock.offset(Clock.system(PARIS), OFFSET);
-        Clock changed = test.withZone(MOSCOW);
-        assertEquals(test.getZone(), PARIS);
-        assertEquals(changed.getZone(), MOSCOW);
-    }
-
-    public void test_withZone_same() {
-        Clock test = Clock.offset(Clock.system(PARIS), OFFSET);
-        Clock changed = test.withZone(PARIS);
-        assertSame(test, changed);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void test_withZone_null() {
-        Clock.offset(Clock.system(PARIS), OFFSET).withZone(null);
-    }
+//    public void test_withZone() {
+//        Clock test = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock changed = test.withZone(MOSCOW);
+//        assertEquals(test.getZone(), PARIS);
+//        assertEquals(changed.getZone(), MOSCOW);
+//    }
+//
+//    public void test_withZone_same() {
+//        Clock test = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock changed = test.withZone(PARIS);
+//        assertSame(test, changed);
+//    }
+//
+//    @Test(expectedExceptions = NullPointerException.class)
+//    public void test_withZone_null() {
+//        Clock.offset(Clock.system(PARIS), OFFSET).withZone(null);
+//    }
 
     //-----------------------------------------------------------------------
     public void test_equals() {
-        Clock a = Clock.offset(Clock.system(PARIS), OFFSET);
-        Clock b = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock a = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock b = Clock.offset(Clock.system(PARIS), OFFSET);
+        Clock a = Clock.offset(Clock.systemDefaultZone(), OFFSET);
+        Clock b = Clock.offset(Clock.systemDefaultZone(), OFFSET);
         assertEquals(a.equals(a), true);
         assertEquals(a.equals(b), true);
         assertEquals(b.equals(a), true);
         assertEquals(b.equals(b), true);
 
-        Clock c = Clock.offset(Clock.system(MOSCOW), OFFSET);
-        assertEquals(a.equals(c), false);
-
-        Clock d = Clock.offset(Clock.system(PARIS), OFFSET.minusNanos(1));
-        assertEquals(a.equals(d), false);
+//        Clock c = Clock.offset(Clock.system(MOSCOW), OFFSET);
+//        assertEquals(a.equals(c), false);
+//
+//        Clock d = Clock.offset(Clock.system(PARIS), OFFSET.minusNanos(1));
+//        assertEquals(a.equals(d), false);
 
         assertEquals(a.equals(null), false);
         assertEquals(a.equals("other type"), false);
@@ -117,22 +121,25 @@ public class TestClock_Offset extends AbstractTest {
     }
 
     public void test_hashCode() {
-        Clock a = Clock.offset(Clock.system(PARIS), OFFSET);
-        Clock b = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock a = Clock.offset(Clock.system(PARIS), OFFSET);
+//        Clock b = Clock.offset(Clock.system(PARIS), OFFSET);
+        Clock a = Clock.offset(Clock.systemUTC(), OFFSET);
+        Clock b = Clock.offset(Clock.systemUTC(), OFFSET);
         assertEquals(a.hashCode(), a.hashCode());
         assertEquals(a.hashCode(), b.hashCode());
 
-        Clock c = Clock.offset(Clock.system(MOSCOW), OFFSET);
-        assertEquals(a.hashCode() == c.hashCode(), false);
-
-        Clock d = Clock.offset(Clock.system(PARIS), OFFSET.minusNanos(1));
-        assertEquals(a.hashCode() == d.hashCode(), false);
+//        Clock c = Clock.offset(Clock.system(MOSCOW), OFFSET);
+//        assertEquals(a.hashCode() == c.hashCode(), false);
+//
+//        Clock d = Clock.offset(Clock.system(PARIS), OFFSET.minusNanos(1));
+//        assertEquals(a.hashCode() == d.hashCode(), false);
     }
 
     //-----------------------------------------------------------------------
     public void test_toString() {
         Clock test = Clock.offset(Clock.systemUTC(), OFFSET);
-        assertEquals(test.toString(), "OffsetClock[SystemClock[Z],PT2S]");
+//        assertEquals(test.toString(), "OffsetClock[SystemClock[Z],PT2S]");
+        assertEquals(test.toString(), "OffsetClock[SystemClock,PT2S]");
     }
 
 }

--- a/src/test/java/org/threeten/bp/TestClock_System.java
+++ b/src/test/java/org/threeten/bp/TestClock_System.java
@@ -52,13 +52,13 @@ public class TestClock_System extends AbstractTest {
     public void test_isSerializable() throws IOException, ClassNotFoundException {
         assertSerializable(Clock.systemUTC());
         assertSerializable(Clock.systemDefaultZone());
-        assertSerializable(Clock.system(PARIS));
+        //assertSerializable(Clock.system(PARIS));
     }
 
     //-----------------------------------------------------------------------
     public void test_instant() {
         Clock system = Clock.systemUTC();
-        assertEquals(system.getZone(), ZoneOffset.UTC);
+        //assertEquals(system.getZone(), ZoneOffset.UTC);
         for (int i = 0; i < 10000; i++) {
             // assume can eventually get these within 10 milliseconds
             Instant instant = system.instant();
@@ -72,7 +72,7 @@ public class TestClock_System extends AbstractTest {
 
     public void test_millis() {
         Clock system = Clock.systemUTC();
-        assertEquals(system.getZone(), ZoneOffset.UTC);
+        //assertEquals(system.getZone(), ZoneOffset.UTC);
         for (int i = 0; i < 10000; i++) {
             // assume can eventually get these within 10 milliseconds
             long instant = system.millis();
@@ -85,22 +85,22 @@ public class TestClock_System extends AbstractTest {
     }
 
     //-------------------------------------------------------------------------
-    public void test_systemUTC() {
-        Clock test = Clock.systemUTC();
-        assertEquals(test.getZone(), ZoneOffset.UTC);
-        assertEquals(test, Clock.system(ZoneOffset.UTC));
-    }
+//    public void test_systemUTC() {
+//        Clock test = Clock.systemUTC();
+//        assertEquals(test.getZone(), ZoneOffset.UTC);
+//        assertEquals(test, Clock.system(ZoneOffset.UTC));
+//    }
 
-    public void test_systemDefaultZone() {
-        Clock test = Clock.systemDefaultZone();
-        assertEquals(test.getZone(), ZoneId.systemDefault());
-        assertEquals(test, Clock.system(ZoneId.systemDefault()));
-    }
+//    public void test_systemDefaultZone() {
+//        Clock test = Clock.systemDefaultZone();
+//        assertEquals(test.getZone(), ZoneId.systemDefault());
+//        assertEquals(test, Clock.system(ZoneId.systemDefault()));
+//    }
 
-    public void test_system_ZoneId() {
-        Clock test = Clock.system(PARIS);
-        assertEquals(test.getZone(), PARIS);
-    }
+//    public void test_system_ZoneId() {
+//        Clock test = Clock.system(PARIS);
+//        assertEquals(test.getZone(), PARIS);
+//    }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void test_zoneId_nullZoneId() {
@@ -108,29 +108,29 @@ public class TestClock_System extends AbstractTest {
     }
 
     //-------------------------------------------------------------------------
-    public void test_withZone() {
-        Clock test = Clock.system(PARIS);
-        Clock changed = test.withZone(MOSCOW);
-        assertEquals(test.getZone(), PARIS);
-        assertEquals(changed.getZone(), MOSCOW);
-    }
-
-    public void test_withZone_same() {
-        Clock test = Clock.system(PARIS);
-        Clock changed = test.withZone(PARIS);
-        assertSame(test, changed);
-    }
-
-    public void test_withZone_fromUTC() {
-        Clock test = Clock.systemUTC();
-        Clock changed = test.withZone(PARIS);
-        assertEquals(changed.getZone(), PARIS);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void test_withZone_null() {
-        Clock.systemUTC().withZone(null);
-    }
+//    public void test_withZone() {
+//        Clock test = Clock.system(PARIS);
+//        Clock changed = test.withZone(MOSCOW);
+//        assertEquals(test.getZone(), PARIS);
+//        assertEquals(changed.getZone(), MOSCOW);
+//    }
+//
+//    public void test_withZone_same() {
+//        Clock test = Clock.system(PARIS);
+//        Clock changed = test.withZone(PARIS);
+//        assertSame(test, changed);
+//    }
+//
+//    public void test_withZone_fromUTC() {
+//        Clock test = Clock.systemUTC();
+//        Clock changed = test.withZone(PARIS);
+//        assertEquals(changed.getZone(), PARIS);
+//    }
+//
+//    @Test(expectedExceptions = NullPointerException.class)
+//    public void test_withZone_null() {
+//        Clock.systemUTC().withZone(null);
+//    }
 
     //-----------------------------------------------------------------------
     public void test_equals() {
@@ -141,15 +141,15 @@ public class TestClock_System extends AbstractTest {
         assertEquals(b.equals(a), true);
         assertEquals(b.equals(b), true);
 
-        Clock c = Clock.system(PARIS);
-        Clock d = Clock.system(PARIS);
-        assertEquals(c.equals(c), true);
-        assertEquals(c.equals(d), true);
-        assertEquals(d.equals(c), true);
-        assertEquals(d.equals(d), true);
-
-        assertEquals(a.equals(c), false);
-        assertEquals(c.equals(a), false);
+//        Clock c = Clock.system(PARIS);
+//        Clock d = Clock.system(PARIS);
+//        assertEquals(c.equals(c), true);
+//        assertEquals(c.equals(d), true);
+//        assertEquals(d.equals(c), true);
+//        assertEquals(d.equals(d), true);
+//
+//        assertEquals(a.equals(c), false);
+//        assertEquals(c.equals(a), false);
 
         assertEquals(a.equals(null), false);
         assertEquals(a.equals("other type"), false);
@@ -157,19 +157,23 @@ public class TestClock_System extends AbstractTest {
     }
 
     public void test_hashCode() {
-        Clock a = Clock.system(ZoneOffset.UTC);
-        Clock b = Clock.system(ZoneOffset.UTC);
+//        Clock a = Clock.system(ZoneOffset.UTC);
+//        Clock b = Clock.system(ZoneOffset.UTC);
+        Clock a = Clock.systemUTC();
+        Clock b = Clock.systemUTC();
+
         assertEquals(a.hashCode(), a.hashCode());
         assertEquals(a.hashCode(), b.hashCode());
 
-        Clock c = Clock.system(PARIS);
-        assertEquals(a.hashCode() == c.hashCode(), false);
+        //Clock c = Clock.system(PARIS);
+        Clock c = Clock.systemDefaultZone();
+        //assertEquals(a.hashCode() == c.hashCode(), false);
+        assertEquals(a.hashCode() == c.hashCode(), true);
     }
 
     //-----------------------------------------------------------------------
-    public void test_toString() {
-        Clock test = Clock.system(PARIS);
-        assertEquals(test.toString(), "SystemClock[Europe/Paris]");
-    }
-
+//    public void test_toString() {
+//        Clock test = Clock.system(PARIS);
+//        assertEquals(test.toString(), "SystemClock[Europe/Paris]");
+//    }
 }

--- a/src/test/java/org/threeten/bp/TestClock_Tick.java
+++ b/src/test/java/org/threeten/bp/TestClock_Tick.java
@@ -52,9 +52,11 @@ public class TestClock_Tick extends AbstractTest {
 
     //-----------------------------------------------------------------------
     public void test_isSerializable() throws IOException, ClassNotFoundException {
-        assertSerializable(Clock.tickSeconds(PARIS));
-        assertSerializable(Clock.tickMinutes(MOSCOW));
-        assertSerializable(Clock.tick(Clock.fixed(INSTANT, PARIS), AMOUNT));
+//        assertSerializable(Clock.tickSeconds(PARIS));
+//        assertSerializable(Clock.tickMinutes(MOSCOW));
+//        assertSerializable(Clock.tick(Clock.fixed(INSTANT, PARIS), AMOUNT));
+
+        assertSerializable(Clock.tick(Clock.systemUTC(), AMOUNT));
     }
 
     //-----------------------------------------------------------------------
@@ -83,13 +85,15 @@ public class TestClock_Tick extends AbstractTest {
     }
 
     public void test_tick_ClockDuration_zeroDuration() {
-        Clock underlying = Clock.system(PARIS);
+        //Clock underlying = Clock.system(PARIS);
+        Clock underlying = Clock.systemUTC();
         Clock test = Clock.tick(underlying, Duration.ZERO);
         assertSame(test, underlying);  // spec says same
     }
 
     public void test_tick_ClockDuration_1nsDuration() {
-        Clock underlying = Clock.system(PARIS);
+        //Clock underlying = Clock.system(PARIS);
+        Clock underlying = Clock.systemUTC();
         Clock test = Clock.tick(underlying, Duration.ofNanos(1));
         assertSame(test, underlying);  // spec says same
     }
@@ -135,26 +139,33 @@ public class TestClock_Tick extends AbstractTest {
     }
 
     //-----------------------------------------------------------------------
+//    public void test_tickSeconds_ZoneId() throws Exception {
+//        Clock test = Clock.tickSeconds(PARIS);
+//        assertEquals(test.getZone(), PARIS);
+//        assertEquals(test.instant().getNano(), 0);
+//        Thread.sleep(100);
+//        assertEquals(test.instant().getNano(), 0);
+//    }
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void test_tickSeconds_ZoneId() throws Exception {
-        Clock test = Clock.tickSeconds(PARIS);
-        assertEquals(test.getZone(), PARIS);
-        assertEquals(test.instant().getNano(), 0);
-        Thread.sleep(100);
-        assertEquals(test.instant().getNano(), 0);
+        Clock.tickSeconds(PARIS);
     }
-
     @Test(expectedExceptions = NullPointerException.class)
     public void test_tickSeconds_ZoneId_nullZoneId() {
         Clock.tickSeconds(null);
     }
 
     //-----------------------------------------------------------------------
+//    public void test_tickMinutes_ZoneId() {
+//        Clock test = Clock.tickMinutes(PARIS);
+//        assertEquals(test.getZone(), PARIS);
+//        Instant instant = test.instant();
+//        assertEquals(instant.getEpochSecond() % 60, 0);
+//        assertEquals(instant.getNano(), 0);
+//    }
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void test_tickMinutes_ZoneId() {
-        Clock test = Clock.tickMinutes(PARIS);
-        assertEquals(test.getZone(), PARIS);
-        Instant instant = test.instant();
-        assertEquals(instant.getEpochSecond() % 60, 0);
-        assertEquals(instant.getNano(), 0);
+        Clock.tickMinutes(PARIS);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -163,38 +174,40 @@ public class TestClock_Tick extends AbstractTest {
     }
 
     //-------------------------------------------------------------------------
-    public void test_withZone() {
-        Clock test = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
-        Clock changed = test.withZone(MOSCOW);
-        assertEquals(test.getZone(), PARIS);
-        assertEquals(changed.getZone(), MOSCOW);
-    }
-
-    public void test_withZone_same() {
-        Clock test = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
-        Clock changed = test.withZone(PARIS);
-        assertSame(test, changed);
-    }
-
-    @Test(expectedExceptions = NullPointerException.class)
-    public void test_withZone_null() {
-        Clock.tick(Clock.system(PARIS), Duration.ofMillis(500)).withZone(null);
-    }
+//    public void test_withZone() {
+//        Clock test = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock changed = test.withZone(MOSCOW);
+//        assertEquals(test.getZone(), PARIS);
+//        assertEquals(changed.getZone(), MOSCOW);
+//    }
+//
+//    public void test_withZone_same() {
+//        Clock test = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock changed = test.withZone(PARIS);
+//        assertSame(test, changed);
+//    }
+//
+//    @Test(expectedExceptions = NullPointerException.class)
+//    public void test_withZone_null() {
+//        Clock.tick(Clock.system(PARIS), Duration.ofMillis(500)).withZone(null);
+//    }
 
     //-----------------------------------------------------------------------
     public void test__equals() {
-        Clock a = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
-        Clock b = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock a = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock b = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+        Clock a = Clock.tick(Clock.systemUTC(), Duration.ofMillis(500));
+        Clock b = Clock.tick(Clock.systemUTC(), Duration.ofMillis(500));
         assertEquals(a.equals(a), true);
         assertEquals(a.equals(b), true);
         assertEquals(b.equals(a), true);
         assertEquals(b.equals(b), true);
 
-        Clock c = Clock.tick(Clock.system(MOSCOW), Duration.ofMillis(500));
-        assertEquals(a.equals(c), false);
-
-        Clock d = Clock.tick(Clock.system(PARIS), Duration.ofMillis(499));
-        assertEquals(a.equals(d), false);
+//        Clock c = Clock.tick(Clock.system(MOSCOW), Duration.ofMillis(500));
+//        assertEquals(a.equals(c), false);
+//
+//        Clock d = Clock.tick(Clock.system(PARIS), Duration.ofMillis(499));
+//        assertEquals(a.equals(d), false);
 
         assertEquals(a.equals(null), false);
         assertEquals(a.equals("other type"), false);
@@ -202,22 +215,24 @@ public class TestClock_Tick extends AbstractTest {
     }
 
     public void test_hashCode() {
-        Clock a = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
-        Clock b = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock a = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+//        Clock b = Clock.tick(Clock.system(PARIS), Duration.ofMillis(500));
+        Clock a = Clock.tick(Clock.systemUTC(), Duration.ofMillis(500));
+        Clock b = Clock.tick(Clock.systemUTC(), Duration.ofMillis(500));
         assertEquals(a.hashCode(), a.hashCode());
         assertEquals(a.hashCode(), b.hashCode());
 
-        Clock c = Clock.tick(Clock.system(MOSCOW), Duration.ofMillis(500));
-        assertEquals(a.hashCode() == c.hashCode(), false);
-
-        Clock d = Clock.tick(Clock.system(PARIS), Duration.ofMillis(499));
-        assertEquals(a.hashCode() == d.hashCode(), false);
+//        Clock c = Clock.tick(Clock.system(MOSCOW), Duration.ofMillis(500));
+//        assertEquals(a.hashCode() == c.hashCode(), false);
+//
+//        Clock d = Clock.tick(Clock.system(PARIS), Duration.ofMillis(499));
+//        assertEquals(a.hashCode() == d.hashCode(), false);
     }
 
     //-----------------------------------------------------------------------
     public void test_toString() {
         Clock test = Clock.tick(Clock.systemUTC(), Duration.ofMillis(500));
-        assertEquals(test.toString(), "TickClock[SystemClock[Z],PT0.5S]");
+        assertEquals(test.toString(), "TickClock[SystemClock,PT0.5S]");
     }
 
 }

--- a/src/test/java/org/threeten/bp/TestLocalDate.java
+++ b/src/test/java/org/threeten/bp/TestLocalDate.java
@@ -216,20 +216,20 @@ public class TestLocalDate extends AbstractDateTimeTest {
         LocalDate.now((ZoneId) null);
     }
 
-    @Test
-    public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        LocalDate expected = LocalDate.now(Clock.system(zone));
-        LocalDate test = LocalDate.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = LocalDate.now(Clock.system(zone));
-            test = LocalDate.now(zone);
-        }
-        assertEquals(test, expected);
-    }
+//    @Test
+//    public void now_ZoneId() {
+//        ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        LocalDate expected = LocalDate.now(Clock.system(zone));
+//        LocalDate test = LocalDate.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+//            expected = LocalDate.now(Clock.system(zone));
+//            test = LocalDate.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
 
     //-----------------------------------------------------------------------
     // now(Clock)
@@ -255,7 +255,8 @@ public class TestLocalDate extends AbstractDateTimeTest {
     public void now_Clock_allSecsInDay_offset() {
         for (int i = 0; i < (2 * 24 * 60 * 60); i++) {
             Instant instant = Instant.ofEpochSecond(i);
-            Clock clock = Clock.fixed(instant.minusSeconds(OFFSET_PONE.getTotalSeconds()), OFFSET_PONE);
+            //Clock clock = Clock.fixed(instant.minusSeconds(OFFSET_PONE.getTotalSeconds()), OFFSET_PONE);
+            Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
             LocalDate test = LocalDate.now(clock);
             assertEquals(test.getYear(), 1970);
             assertEquals(test.getMonth(), Month.JANUARY);

--- a/src/test/java/org/threeten/bp/TestLocalDateTime.java
+++ b/src/test/java/org/threeten/bp/TestLocalDateTime.java
@@ -248,20 +248,20 @@ public class TestLocalDateTime extends AbstractDateTimeTest {
         LocalDateTime.now((ZoneId) null);
     }
 
-    @Test
-    public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        LocalDateTime expected = LocalDateTime.now(Clock.system(zone));
-        LocalDateTime test = LocalDateTime.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = LocalDateTime.now(Clock.system(zone));
-            test = LocalDateTime.now(zone);
-        }
-        assertEquals(test, expected);
-    }
+//    @Test
+//    public void now_ZoneId() {
+//        ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        LocalDateTime expected = LocalDateTime.now(Clock.system(zone));
+//        LocalDateTime test = LocalDateTime.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+//            expected = LocalDateTime.now(Clock.system(zone));
+//            test = LocalDateTime.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
 
     //-----------------------------------------------------------------------
     // now(Clock)
@@ -291,7 +291,8 @@ public class TestLocalDateTime extends AbstractDateTimeTest {
     public void now_Clock_allSecsInDay_offset() {
         for (int i = 0; i < (2 * 24 * 60 * 60); i++) {
             Instant instant = Instant.ofEpochSecond(i).plusNanos(123456789L);
-            Clock clock = Clock.fixed(instant.minusSeconds(OFFSET_PONE.getTotalSeconds()), OFFSET_PONE);
+            //Clock clock = Clock.fixed(instant.minusSeconds(OFFSET_PONE.getTotalSeconds()), OFFSET_PONE);
+            Clock clock = Clock.fixed(instant, ZoneOffset.UTC);
             LocalDateTime test = LocalDateTime.now(clock);
             assertEquals(test.getYear(), 1970);
             assertEquals(test.getMonth(), Month.JANUARY);

--- a/src/test/java/org/threeten/bp/TestLocalTime.java
+++ b/src/test/java/org/threeten/bp/TestLocalTime.java
@@ -229,20 +229,20 @@ public class TestLocalTime extends AbstractDateTimeTest {
         LocalTime.now((ZoneId) null);
     }
 
-    @Test
-    public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        LocalTime expected = LocalTime.now(Clock.system(zone));
-        LocalTime test = LocalTime.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = LocalTime.now(Clock.system(zone));
-            test = LocalTime.now(zone);
-        }
-        assertEquals(test, expected);
-    }
+//    @Test
+//    public void now_ZoneId() {
+//        ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        LocalTime expected = LocalTime.now(Clock.system(zone));
+//        LocalTime test = LocalTime.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+//            expected = LocalTime.now(Clock.system(zone));
+//            test = LocalTime.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
 
     //-----------------------------------------------------------------------
     // now(Clock)

--- a/src/test/java/org/threeten/bp/TestOffsetDateTime.java
+++ b/src/test/java/org/threeten/bp/TestOffsetDateTime.java
@@ -182,18 +182,23 @@ public class TestOffsetDateTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+//    @Test
+//    public void now() {
+//        OffsetDateTime expected = OffsetDateTime.now(Clock.systemDefaultZone());
+//        OffsetDateTime test = OffsetDateTime.now();
+//        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+//        if (diff >= 100000000) {
+//            // may be date change
+//            expected = OffsetDateTime.now(Clock.systemDefaultZone());
+//            test = OffsetDateTime.now();
+//            diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+//        }
+//        assertTrue(diff < 100000000);  // less than 0.1 secs
+//    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void now() {
-        OffsetDateTime expected = OffsetDateTime.now(Clock.systemDefaultZone());
-        OffsetDateTime test = OffsetDateTime.now();
-        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
-        if (diff >= 100000000) {
-            // may be date change
-            expected = OffsetDateTime.now(Clock.systemDefaultZone());
-            test = OffsetDateTime.now();
-            diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
-        }
-        assertTrue(diff < 100000000);  // less than 0.1 secs
+        OffsetDateTime.now(Clock.systemDefaultZone());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/bp/TestOffsetTime.java
+++ b/src/test/java/org/threeten/bp/TestOffsetTime.java
@@ -159,16 +159,16 @@ public class TestOffsetTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
-    public void now() {
-        ZonedDateTime nowDT = ZonedDateTime.now();
-
-        OffsetTime expected = OffsetTime.now(Clock.systemDefaultZone());
-        OffsetTime test = OffsetTime.now();
-        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
-        assertTrue(diff < 100000000);  // less than 0.1 secs
-        assertEquals(test.getOffset(), nowDT.getOffset());
-    }
+//    @Test
+//    public void now() {
+//        ZonedDateTime nowDT = ZonedDateTime.now();
+//
+//        OffsetTime expected = OffsetTime.now(Clock.systemDefaultZone());
+//        OffsetTime test = OffsetTime.now();
+//        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+//        assertTrue(diff < 100000000);  // less than 0.1 secs
+//        assertEquals(test.getOffset(), nowDT.getOffset());
+//    }
 
     //-----------------------------------------------------------------------
     // now(Clock)

--- a/src/test/java/org/threeten/bp/TestZonedDateTime.java
+++ b/src/test/java/org/threeten/bp/TestZonedDateTime.java
@@ -191,18 +191,23 @@ public class TestZonedDateTime extends AbstractDateTimeTest {
     //-----------------------------------------------------------------------
     // now()
     //-----------------------------------------------------------------------
-    @Test
+//    @Test
+//    public void now() {
+//        ZonedDateTime expected = ZonedDateTime.now(Clock.systemDefaultZone());
+//        ZonedDateTime test = ZonedDateTime.now();
+//        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+//        if (diff >= 100000000) {
+//            // may be date change
+//            expected = ZonedDateTime.now(Clock.systemDefaultZone());
+//            test = ZonedDateTime.now();
+//            diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
+//        }
+//        assertTrue(diff < 100000000);  // less than 0.1 secs
+//    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void now() {
-        ZonedDateTime expected = ZonedDateTime.now(Clock.systemDefaultZone());
-        ZonedDateTime test = ZonedDateTime.now();
-        long diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
-        if (diff >= 100000000) {
-            // may be date change
-            expected = ZonedDateTime.now(Clock.systemDefaultZone());
-            test = ZonedDateTime.now();
-            diff = Math.abs(test.toLocalTime().toNanoOfDay() - expected.toLocalTime().toNanoOfDay());
-        }
-        assertTrue(diff < 100000000);  // less than 0.1 secs
+        ZonedDateTime.now(Clock.systemDefaultZone());
     }
 
     //-----------------------------------------------------------------------
@@ -213,19 +218,25 @@ public class TestZonedDateTime extends AbstractDateTimeTest {
         ZonedDateTime.now((ZoneId) null);
     }
 
-    @Test
+//    @Test
+//    public void now_ZoneId() {
+//        ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        //ZonedDateTime expected = ZonedDateTime.now(Clock.system(zone));
+//        ZonedDateTime expected = ZonedDateTime.now(Clock.systemUTC());
+//        ZonedDateTime test = ZonedDateTime.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+//            expected = ZonedDateTime.now(Clock.system(zone));
+//            test = ZonedDateTime.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        ZonedDateTime expected = ZonedDateTime.now(Clock.system(zone));
-        ZonedDateTime test = ZonedDateTime.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = ZonedDateTime.now(Clock.system(zone));
-            test = ZonedDateTime.now(zone);
-        }
-        assertEquals(test, expected);
+        ZonedDateTime.now(Clock.systemUTC());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/bp/temporal/TestMonthDay.java
+++ b/src/test/java/org/threeten/bp/temporal/TestMonthDay.java
@@ -149,20 +149,20 @@ public class TestMonthDay extends AbstractDateTimeTest {
         MonthDay.now((ZoneId) null);
     }
 
-    @Test
-    public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        MonthDay expected = MonthDay.now(Clock.system(zone));
-        MonthDay test = MonthDay.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = MonthDay.now(Clock.system(zone));
-            test = MonthDay.now(zone);
-        }
-        assertEquals(test, expected);
-    }
+//    @Test
+//    public void now_ZoneId() {
+//        ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        MonthDay expected = MonthDay.now(Clock.system(zone));
+//        MonthDay test = MonthDay.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+//            expected = MonthDay.now(Clock.system(zone));
+//            test = MonthDay.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
 
     //-----------------------------------------------------------------------
     // now(Clock)

--- a/src/test/java/org/threeten/bp/temporal/TestYear.java
+++ b/src/test/java/org/threeten/bp/temporal/TestYear.java
@@ -142,19 +142,28 @@ public class TestYear extends AbstractDateTimeTest {
         Year.now((ZoneId) null);
     }
 
-    @Test
+//    @Test
+//    public void now_ZoneId() {
+//        //ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        ZoneId zone = ZoneId.of("UTC");
+//
+//        //Year expected = Year.now(Clock.system(zone));
+//        Year expected = Year.now(Clock.systemUTC());
+//        Year test = Year.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+////            expected = Year.now(Clock.system(zone));
+//            expected = Year.now(Clock.systemUTC());
+//            test = Year.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
     public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        Year expected = Year.now(Clock.system(zone));
-        Year test = Year.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = Year.now(Clock.system(zone));
-            test = Year.now(zone);
-        }
-        assertEquals(test, expected);
+        Year.now(ZoneId.systemDefault());
     }
 
     //-----------------------------------------------------------------------

--- a/src/test/java/org/threeten/bp/temporal/TestYearMonth.java
+++ b/src/test/java/org/threeten/bp/temporal/TestYearMonth.java
@@ -155,19 +155,28 @@ public class TestYearMonth extends AbstractDateTimeTest {
         YearMonth.now((ZoneId) null);
     }
 
+//    @Test
+//    public void now_ZoneId() {
+//        //ZoneId zone = ZoneId.of("UTC+01:02:03");
+//        ZoneId zone = ZoneId.of("UTC");
+//
+//        //YearMonth expected = YearMonth.now(Clock.system(zone));
+//        YearMonth expected = YearMonth.now(Clock.systemUTC());
+//        YearMonth test = YearMonth.now(zone);
+//        for (int i = 0; i < 100; i++) {
+//            if (expected.equals(test)) {
+//                return;
+//            }
+////            expected = YearMonth.now(Clock.system(zone));
+//            expected = YearMonth.now(Clock.systemUTC());
+//            test = YearMonth.now(zone);
+//        }
+//        assertEquals(test, expected);
+//    }
+
     @Test
     public void now_ZoneId() {
-        ZoneId zone = ZoneId.of("UTC+01:02:03");
-        YearMonth expected = YearMonth.now(Clock.system(zone));
-        YearMonth test = YearMonth.now(zone);
-        for (int i = 0; i < 100; i++) {
-            if (expected.equals(test)) {
-                return;
-            }
-            expected = YearMonth.now(Clock.system(zone));
-            test = YearMonth.now(zone);
-        }
-        assertEquals(test, expected);
+        YearMonth.now(Clock.systemUTC());
     }
 
     //-----------------------------------------------------------------------


### PR DESCRIPTION
- getZone and withZone made @GwtIncompatible.
- Clock sub classes that require a ZoneId made @GwtIncompatible.