### PR TITLE
POM maven central repo added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,17 @@
                 <enabled>true</enabled>
             </snapshots>
         </repository>
+        <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>http://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+        </repository>
     </repositories>
 
     <dependencies>


### PR DESCRIPTION
- Solves travis-ci defaulting to google mirror which is incomplete.