### PR TITLE
Serialization methods marked @GwtIncompatible

### DIFF
--- a/src/main/java/org/threeten/bp/Duration.java
+++ b/src/main/java/org/threeten/bp/Duration.java
@@ -54,6 +54,7 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.format.DateTimeParseException;
 import org.threeten.bp.jdk8.Jdk8Methods;
 import org.threeten.bp.temporal.ChronoField;
@@ -1238,6 +1239,7 @@ public final class Duration
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.DURATION_TYPE, this);
     }
@@ -1247,15 +1249,18 @@ public final class Duration
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeLong(seconds);
         out.writeInt(nanos);
     }
 
+    @GwtIncompatible
     static Duration readExternal(DataInput in) throws IOException {
         long seconds = in.readLong();
         int nanos = in.readInt();

--- a/src/main/java/org/threeten/bp/Instant.java
+++ b/src/main/java/org/threeten/bp/Instant.java
@@ -48,6 +48,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
 import org.threeten.bp.jdk8.DefaultInterfaceTemporalAccessor;
@@ -1163,6 +1164,7 @@ public final class Instant
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.INSTANT_TYPE, this);
     }
@@ -1172,15 +1174,18 @@ public final class Instant
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeLong(seconds);
         out.writeInt(nanos);
     }
 
+    @GwtIncompatible
     static Instant readExternal(DataInput in) throws IOException {
         long seconds = in.readLong();
         int nanos = in.readInt();

--- a/src/main/java/org/threeten/bp/LocalDate.java
+++ b/src/main/java/org/threeten/bp/LocalDate.java
@@ -51,6 +51,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.ChronoLocalDate;
 import org.threeten.bp.chrono.Era;
 import org.threeten.bp.chrono.IsoChronology;
@@ -1862,6 +1863,7 @@ public final class LocalDate
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.LOCAL_DATE_TYPE, this);
     }
@@ -1871,16 +1873,19 @@ public final class LocalDate
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeInt(year);
         out.writeByte(month);
         out.writeByte(day);
     }
 
+    @GwtIncompatible
     static LocalDate readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         int month = in.readByte();

--- a/src/main/java/org/threeten/bp/LocalDateTime.java
+++ b/src/main/java/org/threeten/bp/LocalDateTime.java
@@ -1842,6 +1842,7 @@ public final class LocalDateTime
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.LOCAL_DATE_TIME_TYPE, this);
     }
@@ -1851,15 +1852,18 @@ public final class LocalDateTime
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         date.writeExternal(out);
         time.writeExternal(out);
     }
 
+    @GwtIncompatible
     static LocalDateTime readExternal(DataInput in) throws IOException {
         LocalDate date = LocalDate.readExternal(in);
         LocalTime time = LocalTime.readExternal(in);

--- a/src/main/java/org/threeten/bp/LocalTime.java
+++ b/src/main/java/org/threeten/bp/LocalTime.java
@@ -47,6 +47,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
 import org.threeten.bp.jdk8.DefaultInterfaceTemporalAccessor;
@@ -1508,6 +1509,7 @@ public final class LocalTime
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.LOCAL_TIME_TYPE, this);
     }
@@ -1517,10 +1519,12 @@ public final class LocalTime
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         if (nano == 0) {
             if (second == 0) {
@@ -1543,6 +1547,7 @@ public final class LocalTime
         }
     }
 
+    @GwtIncompatible
     static LocalTime readExternal(DataInput in) throws IOException {
         int hour = in.readByte();
         int minute = 0;

--- a/src/main/java/org/threeten/bp/MonthDay.java
+++ b/src/main/java/org/threeten/bp/MonthDay.java
@@ -41,6 +41,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.Chronology;
 import org.threeten.bp.chrono.IsoChronology;
 import org.threeten.bp.format.DateTimeFormatter;
@@ -721,6 +722,7 @@ public final class MonthDay
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.MONTH_DAY_TYPE, this);
     }
@@ -730,15 +732,18 @@ public final class MonthDay
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeByte(month);
         out.writeByte(day);
     }
 
+    @GwtIncompatible
     static MonthDay readExternal(DataInput in) throws IOException {
         byte month = in.readByte();
         byte day = in.readByte();

--- a/src/main/java/org/threeten/bp/OffsetDateTime.java
+++ b/src/main/java/org/threeten/bp/OffsetDateTime.java
@@ -45,6 +45,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.Comparator;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.IsoChronology;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
@@ -1792,6 +1793,7 @@ public final class OffsetDateTime
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.OFFSET_DATE_TIME_TYPE, this);
     }
@@ -1801,15 +1803,18 @@ public final class OffsetDateTime
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         dateTime.writeExternal(out);
         offset.writeExternal(out);
     }
 
+    @GwtIncompatible
     static OffsetDateTime readExternal(DataInput in) throws IOException {
         LocalDateTime dateTime = LocalDateTime.readExternal(in);
         ZoneOffset offset = ZoneOffset.readExternal(in);

--- a/src/main/java/org/threeten/bp/OffsetTime.java
+++ b/src/main/java/org/threeten/bp/OffsetTime.java
@@ -46,6 +46,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
 import org.threeten.bp.jdk8.DefaultInterfaceTemporalAccessor;
@@ -1289,6 +1290,7 @@ public final class OffsetTime
     }
 
     // -----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.OFFSET_TIME_TYPE, this);
     }
@@ -1298,15 +1300,18 @@ public final class OffsetTime
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         time.writeExternal(out);
         offset.writeExternal(out);
     }
 
+    @GwtIncompatible
     static OffsetTime readExternal(DataInput in) throws IOException {
         LocalTime time = LocalTime.readExternal(in);
         ZoneOffset offset = ZoneOffset.readExternal(in);

--- a/src/main/java/org/threeten/bp/Year.java
+++ b/src/main/java/org/threeten/bp/Year.java
@@ -47,6 +47,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.Chronology;
 import org.threeten.bp.chrono.IsoChronology;
 import org.threeten.bp.format.DateTimeFormatter;
@@ -959,6 +960,7 @@ public final class Year
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.YEAR_TYPE, this);
     }
@@ -968,14 +970,17 @@ public final class Year
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeInt(year);
     }
 
+    @GwtIncompatible
     static Year readExternal(DataInput in) throws IOException {
         return Year.of(in.readInt());
     }

--- a/src/main/java/org/threeten/bp/YearMonth.java
+++ b/src/main/java/org/threeten/bp/YearMonth.java
@@ -50,6 +50,7 @@ import java.io.InvalidObjectException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.Chronology;
 import org.threeten.bp.chrono.IsoChronology;
 import org.threeten.bp.format.DateTimeFormatter;
@@ -1081,6 +1082,7 @@ public final class YearMonth
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.YEAR_MONTH_TYPE, this);
     }
@@ -1090,15 +1092,18 @@ public final class YearMonth
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeInt(year);
         out.writeByte(month);
     }
 
+    @GwtIncompatible
     static YearMonth readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         byte month = in.readByte();

--- a/src/main/java/org/threeten/bp/ZoneOffset.java
+++ b/src/main/java/org/threeten/bp/ZoneOffset.java
@@ -42,6 +42,7 @@ import java.io.Serializable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.jdk8.Jdk8Methods;
 import org.threeten.bp.temporal.ChronoField;
 import org.threeten.bp.temporal.Temporal;
@@ -725,6 +726,7 @@ public final class ZoneOffset
     }
 
     // -----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.ZONE_OFFSET_TYPE, this);
     }
@@ -734,16 +736,19 @@ public final class ZoneOffset
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     @Override
     void write(DataOutput out) throws IOException {
         out.writeByte(Ser.ZONE_OFFSET_TYPE);
         writeExternal(out);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         final int offsetSecs = totalSeconds;
         int offsetByte = offsetSecs % 900 == 0 ? offsetSecs / 900 : 127;  // compress to -72 to +72
@@ -753,6 +758,7 @@ public final class ZoneOffset
         }
     }
 
+    @GwtIncompatible
     static ZoneOffset readExternal(DataInput in) throws IOException {
         int offsetByte = in.readByte();
         return (offsetByte == 127 ? ZoneOffset.ofTotalSeconds(in.readInt()) : ZoneOffset.ofTotalSeconds(offsetByte * 900));

--- a/src/main/java/org/threeten/bp/ZoneRegion.java
+++ b/src/main/java/org/threeten/bp/ZoneRegion.java
@@ -39,6 +39,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.regex.Pattern;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.jdk8.Jdk8Methods;
 import org.threeten.bp.zone.ZoneRules;
 import org.threeten.bp.zone.ZoneRulesException;
@@ -178,6 +179,7 @@ final class ZoneRegion extends ZoneId implements Serializable {
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.ZONE_REGION_TYPE, this);
     }
@@ -187,20 +189,24 @@ final class ZoneRegion extends ZoneId implements Serializable {
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     @Override
     void write(DataOutput out) throws IOException {
         out.writeByte(Ser.ZONE_REGION_TYPE);
         writeExternal(out);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeUTF(id);
     }
 
+    @GwtIncompatible
     static ZoneId readExternal(DataInput in) throws IOException {
         String id = in.readUTF();
         return ofLenient(id);

--- a/src/main/java/org/threeten/bp/ZonedDateTime.java
+++ b/src/main/java/org/threeten/bp/ZonedDateTime.java
@@ -43,6 +43,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.List;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.chrono.ChronoZonedDateTime;
 import org.threeten.bp.format.DateTimeFormatter;
 import org.threeten.bp.format.DateTimeParseException;
@@ -2097,6 +2098,7 @@ public final class ZonedDateTime
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.ZONED_DATE_TIME_TYPE, this);
     }
@@ -2106,16 +2108,19 @@ public final class ZonedDateTime
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         dateTime.writeExternal(out);
         offset.writeExternal(out);
         zone.write(out);
     }
 
+    @GwtIncompatible
     static ZonedDateTime readExternal(DataInput in) throws IOException {
         LocalDateTime dateTime = LocalDateTime.readExternal(in);
         ZoneOffset offset = ZoneOffset.readExternal(in);

--- a/src/main/java/org/threeten/bp/chrono/ChronoLocalDateTimeImpl.java
+++ b/src/main/java/org/threeten/bp/chrono/ChronoLocalDateTimeImpl.java
@@ -38,6 +38,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.LocalTime;
 import org.threeten.bp.ZoneId;
 import org.threeten.bp.jdk8.Jdk8Methods;
@@ -348,15 +349,18 @@ final class ChronoLocalDateTimeImpl<D extends ChronoLocalDate>
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.CHRONO_LOCALDATETIME_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(ObjectOutput out) throws IOException {
         out.writeObject(date);
         out.writeObject(time);
     }
 
+    @GwtIncompatible
     static ChronoLocalDateTime<?> readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         ChronoLocalDate date = (ChronoLocalDate) in.readObject();
         LocalTime time = (LocalTime) in.readObject();

--- a/src/main/java/org/threeten/bp/chrono/ChronoZonedDateTimeImpl.java
+++ b/src/main/java/org/threeten/bp/chrono/ChronoZonedDateTimeImpl.java
@@ -41,6 +41,7 @@ import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.List;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDateTime;
 import org.threeten.bp.ZoneId;
@@ -274,6 +275,7 @@ final class ChronoZonedDateTimeImpl<D extends ChronoLocalDate>
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.CHRONO_ZONEDDATETIME_TYPE, this);
     }
@@ -283,16 +285,19 @@ final class ChronoZonedDateTimeImpl<D extends ChronoLocalDate>
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(ObjectOutput out) throws IOException {
         out.writeObject(dateTime);
         out.writeObject(offset);
         out.writeObject(zone);
     }
 
+    @GwtIncompatible
     static ChronoZonedDateTime<?> readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
         ChronoLocalDateTime<?> dateTime = (ChronoLocalDateTime<?>) in.readObject();
         ZoneOffset offset = (ZoneOffset) in.readObject();

--- a/src/main/java/org/threeten/bp/chrono/Chronology.java
+++ b/src/main/java/org/threeten/bp/chrono/Chronology.java
@@ -46,6 +46,7 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Clock;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.Instant;
@@ -872,6 +873,7 @@ public abstract class Chronology implements Comparable<Chronology> {
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.CHRONO_TYPE, this);
     }
@@ -881,14 +883,17 @@ public abstract class Chronology implements Comparable<Chronology> {
      * @return never
      * @throws InvalidObjectException always
      */
+    @GwtIncompatible
     private Object readResolve() throws ObjectStreamException {
         throw new InvalidObjectException("Deserialization via serialization delegate");
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeUTF(getId());
     }
 
+    @GwtIncompatible
     static Chronology readExternal(DataInput in) throws IOException {
         String id = in.readUTF();
         return Chronology.of(id);

--- a/src/main/java/org/threeten/bp/chrono/HijrahDate.java
+++ b/src/main/java/org/threeten/bp/chrono/HijrahDate.java
@@ -54,6 +54,7 @@ import java.util.StringTokenizer;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Clock;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.DayOfWeek;
@@ -1758,10 +1759,12 @@ public final class HijrahDate
         }
     }
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.HIJRAH_DATE_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         // HijrahChrono is implicit in the Hijrah_DATE_TYPE
         out.writeInt(get(YEAR));
@@ -1769,6 +1772,7 @@ public final class HijrahDate
         out.writeByte(get(DAY_OF_MONTH));
     }
 
+    @GwtIncompatible
     static ChronoLocalDate readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         int month = in.readByte();

--- a/src/main/java/org/threeten/bp/chrono/HijrahEra.java
+++ b/src/main/java/org/threeten/bp/chrono/HijrahEra.java
@@ -38,6 +38,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Locale;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.format.TextStyle;
@@ -184,14 +185,17 @@ public enum HijrahEra implements Era {
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.HIJRAH_ERA_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeByte(this.getValue());
     }
 
+    @GwtIncompatible
     static HijrahEra readExternal(DataInput in) throws IOException {
         byte eraValue = in.readByte();
         return HijrahEra.of(eraValue);

--- a/src/main/java/org/threeten/bp/chrono/JapaneseDate.java
+++ b/src/main/java/org/threeten/bp/chrono/JapaneseDate.java
@@ -42,6 +42,7 @@ import java.io.ObjectInputStream;
 import java.io.Serializable;
 import java.util.Calendar;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Clock;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.LocalDate;
@@ -585,10 +586,12 @@ public final class JapaneseDate
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.JAPANESE_DATE_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         // JapaneseChrono is implicit in the JAPANESE_DATE_TYPE
         out.writeInt(get(YEAR));
@@ -596,6 +599,7 @@ public final class JapaneseDate
         out.writeByte(get(DAY_OF_MONTH));
     }
 
+    @GwtIncompatible
     static ChronoLocalDate readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         int month = in.readByte();

--- a/src/main/java/org/threeten/bp/chrono/JapaneseEra.java
+++ b/src/main/java/org/threeten/bp/chrono/JapaneseEra.java
@@ -40,6 +40,7 @@ import java.io.Serializable;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.jdk8.DefaultInterfaceEra;
@@ -327,14 +328,17 @@ public final class JapaneseEra
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.JAPANESE_ERA_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeByte(this.getValue());
     }
 
+    @GwtIncompatible
     static JapaneseEra readExternal(DataInput in) throws IOException {
         byte eraValue = in.readByte();
         return JapaneseEra.of(eraValue);

--- a/src/main/java/org/threeten/bp/chrono/MinguoDate.java
+++ b/src/main/java/org/threeten/bp/chrono/MinguoDate.java
@@ -41,6 +41,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Clock;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.LocalDate;
@@ -358,10 +359,12 @@ public final class MinguoDate
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.MINGUO_DATE_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         // MinguoChrono is implicit in the MINGUO_DATE_TYPE
         out.writeInt(get(YEAR));
@@ -370,6 +373,7 @@ public final class MinguoDate
 
     }
 
+    @GwtIncompatible
     static ChronoLocalDate readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         int month = in.readByte();

--- a/src/main/java/org/threeten/bp/chrono/MinguoEra.java
+++ b/src/main/java/org/threeten/bp/chrono/MinguoEra.java
@@ -38,6 +38,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Locale;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.format.TextStyle;
@@ -174,14 +175,17 @@ public enum MinguoEra implements Era  {
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.MINGUO_ERA_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeByte(this.getValue());
     }
 
+    @GwtIncompatible
     static MinguoEra readExternal(DataInput in) throws IOException {
         byte eraValue = in.readByte();
         return MinguoEra.of(eraValue);

--- a/src/main/java/org/threeten/bp/chrono/ThaiBuddhistDate.java
+++ b/src/main/java/org/threeten/bp/chrono/ThaiBuddhistDate.java
@@ -41,6 +41,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Clock;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.LocalDate;
@@ -358,10 +359,12 @@ public final class ThaiBuddhistDate
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.THAIBUDDHIST_DATE_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         // MinguoChrono is implicit in the THAIBUDDHIST_DATE_TYPE
         out.writeInt(this.get(YEAR));
@@ -369,6 +372,7 @@ public final class ThaiBuddhistDate
         out.writeByte(this.get(DAY_OF_MONTH));
     }
 
+    @GwtIncompatible
     static ChronoLocalDate readExternal(DataInput in) throws IOException {
         int year = in.readInt();
         int month = in.readByte();

--- a/src/main/java/org/threeten/bp/chrono/ThaiBuddhistEra.java
+++ b/src/main/java/org/threeten/bp/chrono/ThaiBuddhistEra.java
@@ -38,6 +38,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.Locale;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.DateTimeException;
 import org.threeten.bp.format.DateTimeFormatterBuilder;
 import org.threeten.bp.format.TextStyle;
@@ -173,14 +174,17 @@ public enum ThaiBuddhistEra implements Era {
     }
 
     //-----------------------------------------------------------------------
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.THAIBUDDHIST_ERA_TYPE, this);
     }
 
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeByte(this.getValue());
     }
 
+    @GwtIncompatible
     static ThaiBuddhistEra readExternal(DataInput in) throws IOException {
         byte eraValue = in.readByte();
         return ThaiBuddhistEra.of(eraValue);

--- a/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
+++ b/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDate;
@@ -203,6 +204,7 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
      *
      * @return the replacing object, not null
      */
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.SZR, this);
     }
@@ -213,6 +215,7 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
      * @param out  the output stream, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         out.writeInt(standardTransitions.length);
         for (long trans : standardTransitions) {
@@ -241,6 +244,7 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     static StandardZoneRules readExternal(DataInput in) throws IOException, ClassNotFoundException {
         int stdSize = in.readInt();
         long[] stdTrans = new long[stdSize];

--- a/src/main/java/org/threeten/bp/zone/ZoneOffsetTransition.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneOffsetTransition.java
@@ -39,6 +39,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.Duration;
 import org.threeten.bp.Instant;
 import org.threeten.bp.LocalDateTime;
@@ -143,6 +144,7 @@ public final class ZoneOffsetTransition
      *
      * @return the replacing object, not null
      */
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.ZOT, this);
     }
@@ -153,6 +155,7 @@ public final class ZoneOffsetTransition
      * @param out  the output stream, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         Ser.writeEpochSec(toEpochSecond(), out);
         Ser.writeOffset(offsetBefore, out);
@@ -166,6 +169,7 @@ public final class ZoneOffsetTransition
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     static ZoneOffsetTransition readExternal(DataInput in) throws IOException {
         long epochSecond = Ser.readEpochSec(in);
         ZoneOffset before = Ser.readOffset(in);

--- a/src/main/java/org/threeten/bp/zone/ZoneOffsetTransitionRule.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneOffsetTransitionRule.java
@@ -39,6 +39,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 
+import javaemul.internal.annotations.GwtIncompatible;
 import org.threeten.bp.DayOfWeek;
 import org.threeten.bp.LocalDate;
 import org.threeten.bp.LocalDateTime;
@@ -208,6 +209,7 @@ public final class ZoneOffsetTransitionRule implements Serializable {
      *
      * @return the replacing object, not null
      */
+    @GwtIncompatible
     private Object writeReplace() {
         return new Ser(Ser.ZOTRULE, this);
     }
@@ -218,6 +220,7 @@ public final class ZoneOffsetTransitionRule implements Serializable {
      * @param out  the output stream, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     void writeExternal(DataOutput out) throws IOException {
         final int timeSecs = time.toSecondOfDay() + adjustDays * SECS_PER_DAY;
         final int stdOffset = standardOffset.getTotalSeconds();
@@ -259,6 +262,7 @@ public final class ZoneOffsetTransitionRule implements Serializable {
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     static ZoneOffsetTransitionRule readExternal(DataInput in) throws IOException {
         int data = in.readInt();
         Month month = Month.of(data >>> 28);


### PR DESCRIPTION
- writeReplace, readResolve and helpers.