### PR TITLE
zone package targeted gwtincompatible

### DIFF
--- a/src/main/java/org/threeten/bp/zone/.j2cl-maven-plugin-ignore.txt
+++ b/src/main/java/org/threeten/bp/zone/.j2cl-maven-plugin-ignore.txt
@@ -1,6 +1,6 @@
 #
-# Exclude entire package
+# Only exclude compiler, serialization helpers will be marked with @GwtIncompatible
 #
+TzdbZoneRulesCompiler.*
 
-*
 

--- a/src/main/java/org/threeten/bp/zone/Ser.java
+++ b/src/main/java/org/threeten/bp/zone/Ser.java
@@ -51,7 +51,6 @@ import org.threeten.bp.ZoneOffset;
  *
  * @serial include
  */
-@GwtIncompatible
 final class Ser implements Externalizable {
 
     /**
@@ -95,14 +94,17 @@ final class Ser implements Externalizable {
      *
      * @param out  the data stream to write to, not null
      */
+    @GwtIncompatible
     public void writeExternal(ObjectOutput out) throws IOException {
         writeInternal(type, object, out);
     }
 
+    @GwtIncompatible
     static void write(Object object, DataOutput out) throws IOException {
         writeInternal(SZR, object, out);
     }
 
+    @GwtIncompatible
     private static void writeInternal(byte type, Object object, DataOutput out) throws IOException {
         out.writeByte(type);
         switch (type) {
@@ -166,6 +168,7 @@ final class Ser implements Externalizable {
      * @param out  the output stream, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     static void writeOffset(ZoneOffset offset, DataOutput out) throws IOException {
         final int offsetSecs = offset.getTotalSeconds();
         int offsetByte = offsetSecs % 900 == 0 ? offsetSecs / 900 : 127;  // compress to -72 to +72
@@ -195,6 +198,7 @@ final class Ser implements Externalizable {
      * @param out  the output stream, not null
      * @throws IOException if an error occurs
      */
+    @GwtIncompatible
     static void writeEpochSec(long epochSec, DataOutput out) throws IOException {
         if (epochSec >= -4575744000L && epochSec < 10413792000L && epochSec % 900 == 0) {  // quarter hours between 1825 and 2300
             int store = (int) ((epochSec + 4575744000L) / 900);

--- a/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
+++ b/src/main/java/org/threeten/bp/zone/StandardZoneRules.java
@@ -59,7 +59,6 @@ import org.threeten.bp.jdk8.JdkCollections;
  * <h3>Specification for implementors</h3>
  * This class is immutable and thread-safe.
  */
-@GwtIncompatible
 final class StandardZoneRules extends ZoneRules implements Serializable {
 
     /**
@@ -246,7 +245,6 @@ final class StandardZoneRules extends ZoneRules implements Serializable {
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
-    @GwtIncompatible
     static StandardZoneRules readExternal(DataInput in) throws IOException, ClassNotFoundException {
         int stdSize = in.readInt();
         long[] stdTrans = new long[stdSize];

--- a/src/main/java/org/threeten/bp/zone/TzdbZoneRulesProvider.java
+++ b/src/main/java/org/threeten/bp/zone/TzdbZoneRulesProvider.java
@@ -59,7 +59,6 @@ import org.threeten.bp.jdk8.JdkCollections;
  * <h3>Specification for implementors</h3>
  * This class is immutable and thread-safe.
  */
-@GwtIncompatible
 public final class TzdbZoneRulesProvider extends ZoneRulesProvider {
     // TODO: can this be private/hidden in any way?
     // service loader seems to need it to be public
@@ -87,6 +86,7 @@ public final class TzdbZoneRulesProvider extends ZoneRulesProvider {
      *
      * @throws ZoneRulesException if unable to load
      */
+    @GwtIncompatible
     public TzdbZoneRulesProvider() {
         super();
         if (load(ZoneRulesProvider.class.getClassLoader()) == false) {
@@ -102,6 +102,7 @@ public final class TzdbZoneRulesProvider extends ZoneRulesProvider {
      * @param url  the URL to load, not null
      * @throws ZoneRulesException if unable to load
      */
+    @GwtIncompatible
     public TzdbZoneRulesProvider(URL url) {
         super();
         try {
@@ -166,6 +167,7 @@ public final class TzdbZoneRulesProvider extends ZoneRulesProvider {
      * @return true if updated
      * @throws ZoneRulesException if unable to load
      */
+    @GwtIncompatible
     private boolean load(ClassLoader classLoader) {
         boolean updated = false;
         URL url = null;
@@ -190,6 +192,7 @@ public final class TzdbZoneRulesProvider extends ZoneRulesProvider {
      * @throws IOException if an IO error occurs
      * @throws ZoneRulesException if the data is already loaded for the version
      */
+    @GwtIncompatible
     private boolean load(URL url) throws ClassNotFoundException, IOException, ZoneRulesException {
         boolean updated = false;
         if (loadedUrls.add(url.toExternalForm())) {

--- a/src/main/java/org/threeten/bp/zone/ZoneOffsetTransition.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneOffsetTransition.java
@@ -64,7 +64,6 @@ import org.threeten.bp.jdk8.Jdk8Methods;
  * <h3>Specification for implementors</h3>
  * This class is immutable and thread-safe.
  */
-@GwtIncompatible
 public final class ZoneOffsetTransition
         implements Comparable<ZoneOffsetTransition>, Serializable {
 
@@ -171,7 +170,6 @@ public final class ZoneOffsetTransition
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
-    @GwtIncompatible
     static ZoneOffsetTransition readExternal(DataInput in) throws IOException {
         long epochSecond = Ser.readEpochSec(in);
         ZoneOffset before = Ser.readOffset(in);

--- a/src/main/java/org/threeten/bp/zone/ZoneOffsetTransitionRule.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneOffsetTransitionRule.java
@@ -65,7 +65,6 @@ import org.threeten.bp.jdk8.Jdk8Methods;
  * <h3>Specification for implementors</h3>
  * This class is immutable and thread-safe.
  */
-@GwtIncompatible
 public final class ZoneOffsetTransitionRule implements Serializable {
 
     /**
@@ -264,7 +263,6 @@ public final class ZoneOffsetTransitionRule implements Serializable {
      * @return the created object, not null
      * @throws IOException if an error occurs
      */
-    @GwtIncompatible
     static ZoneOffsetTransitionRule readExternal(DataInput in) throws IOException {
         int data = in.readInt();
         Month month = Month.of(data >>> 28);

--- a/src/main/java/org/threeten/bp/zone/ZoneRules.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneRules.java
@@ -66,7 +66,6 @@ import org.threeten.bp.jdk8.Jdk8Methods;
  * <h3>Specification for implementors</h3>
  * The supplied implementations of this class are immutable and thread-safe.
  */
-@GwtIncompatible
 public abstract class ZoneRules {
 
     /**

--- a/src/main/java/org/threeten/bp/zone/ZoneRulesBuilder.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneRulesBuilder.java
@@ -70,7 +70,6 @@ import org.threeten.bp.zone.ZoneOffsetTransitionRule.TimeDefinition;
  * It must only be used from a single thread.
  * The created instances are immutable and thread-safe.
  */
-@GwtIncompatible
 class ZoneRulesBuilder {
 
     /**

--- a/src/main/java/org/threeten/bp/zone/ZoneRulesException.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneRulesException.java
@@ -43,7 +43,6 @@ import org.threeten.bp.DateTimeException;
  * <h3>Specification for implementors</h3>
  * This class is intended for use in a single thread.
  */
-@GwtIncompatible
 public class ZoneRulesException extends DateTimeException {
 
     /**

--- a/src/main/java/org/threeten/bp/zone/ZoneRulesInitializer.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneRulesInitializer.java
@@ -50,7 +50,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * <p>
  * This class has been added primarily for the benefit of Android.
  */
-@GwtIncompatible
 public abstract class ZoneRulesInitializer {
 
     /**
@@ -118,6 +117,7 @@ public abstract class ZoneRulesInitializer {
     /**
      * Implementation that uses the service loader.
      */
+    @GwtIncompatible
     static class ServiceLoaderZoneRulesInitializer extends ZoneRulesInitializer {
 
         @Override

--- a/src/main/java/org/threeten/bp/zone/ZoneRulesProvider.java
+++ b/src/main/java/org/threeten/bp/zone/ZoneRulesProvider.java
@@ -70,7 +70,6 @@ import org.threeten.bp.jdk8.JdkCollections;
  * When examined in detail, this is a complex problem.
  * Providers may choose to handle dynamic updates, however the default provider does not.
  */
-@GwtIncompatible
 public abstract class ZoneRulesProvider {
 
     /**


### PR DESCRIPTION
- TzdbZoneRulesCompiler marked @GwtIncompatible
- Serialization helpers (writeReplace etc) marked @GwtIncompatible
- Removed previous @GwtIncompatible from ZoneXXX classes.