### PR TITLE
travis.yml dist: trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,5 @@ sudo: false
 language: java
 jdk:
   - oraclejdk9
+
+dist: trusty


### PR DESCRIPTION
- Hopefully this fixes the maven repo problems, and build can pass on travis just like locally.