### PR TITLE
walkingkooka.j2cl.java.time.Locale.ENGLISH constant introduced

### DIFF
--- a/src/main/java/org/threeten/bp/format/DateTimeFormatterBuilder.java
+++ b/src/main/java/org/threeten/bp/format/DateTimeFormatterBuilder.java
@@ -3621,7 +3621,7 @@ public final class DateTimeFormatterBuilder {
                 if (caseSensitive) {
                     return substringMap.get(substring2);
                 } else {
-                    return substringMapCI.get(substring2.toString().toLowerCase(Locale.ENGLISH));
+                    return substringMapCI.get(substring2.toString().toLowerCase(walkingkooka.j2cl.java.time.Locale.ENGLISH));
                 }
             }
 
@@ -3634,14 +3634,14 @@ public final class DateTimeFormatterBuilder {
                 int idLen = newSubstring.length();
                 if (idLen == length) {
                     substringMap.put(newSubstring, null);
-                    substringMapCI.put(newSubstring.toLowerCase(Locale.ENGLISH), null);
+                    substringMapCI.put(newSubstring.toLowerCase(walkingkooka.j2cl.java.time.Locale.ENGLISH), null);
                 } else if (idLen > length) {
                     String substring = newSubstring.substring(0, length);
                     SubstringTree parserTree = substringMap.get(substring);
                     if (parserTree == null) {
                         parserTree = new SubstringTree(idLen);
                         substringMap.put(substring, parserTree);
-                        substringMapCI.put(substring.toLowerCase(Locale.ENGLISH), parserTree);
+                        substringMapCI.put(substring.toLowerCase(walkingkooka.j2cl.java.time.Locale.ENGLISH), parserTree);
                     }
                     parserTree.add(newSubstring);
                 }

--- a/src/main/java/org/threeten/bp/format/SimpleDateTimeTextProvider.java
+++ b/src/main/java/org/threeten/bp/format/SimpleDateTimeTextProvider.java
@@ -237,7 +237,7 @@ final class SimpleDateTimeTextProvider extends DateTimeTextProvider {
             map.put(0L, array[GregorianCalendar.BC]);
             map.put(1L, array[GregorianCalendar.AD]);
             styleMap.put(TextStyle.SHORT, map);
-            if (locale.getLanguage().equals(Locale.ENGLISH.getLanguage())) {
+            if (locale.getLanguage().equals(walkingkooka.j2cl.java.time.Locale.ENGLISH.getLanguage())) {
                 map = new HashMap<Long, String>();
                 map.put(0L, "Before Christ");
                 map.put(1L, "Anno Domini");

--- a/src/main/java/walkingkooka/j2cl/java/time/Locale.java
+++ b/src/main/java/walkingkooka/j2cl/java/time/Locale.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.j2cl.java.time;
+
+public final class Locale {
+
+    public final static java.util.Locale ENGLISH = java.util.Locale.forLanguageTag("EN");
+}

--- a/src/test/java/walkingkooka/j2cl/java/time/LocaleTest.java
+++ b/src/test/java/walkingkooka/j2cl/java/time/LocaleTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 Miroslav Pokorny (github.com/mP1)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package walkingkooka.j2cl.java.time;
+
+import walkingkooka.reflect.ClassTesting;
+import walkingkooka.reflect.JavaVisibility;
+
+public final class LocaleTest implements ClassTesting<Locale> {
+    @Override
+    public JavaVisibility typeVisibility() {
+        return JavaVisibility.PUBLIC;
+    }
+
+    @Override
+    public Class<Locale> type() {
+        return Locale.class;
+    }
+}


### PR DESCRIPTION
- replaces java.util.Locale.ENGLISH which is not provided by walkingkooka:j2cl-java-util-Locale