### PR TITLE
Pattern removed org.threeten.bp.format.DateTimeParseException import

### DIFF
--- a/src/main/java/walkingkooka/j2cl/java/time/Pattern.java
+++ b/src/main/java/walkingkooka/j2cl/java/time/Pattern.java
@@ -17,8 +17,6 @@
 
 package walkingkooka.j2cl.java.time;
 
-import org.threeten.bp.format.DateTimeParseException;
-
 /**
  * Holds functionality equivalent code for {@link Pattern usage}.
  */


### PR DESCRIPTION
- Class is never used DTPE is only mentioned in original javadoc