### PR TITLE
j2cl-java-util-TimeZone 33c2e5364c036750f00a3d7d23ecc62cab9ccc3b 2020…

### DIFF
--- a/src/it/junit-test/pom.xml
+++ b/src/it/junit-test/pom.xml
@@ -220,9 +220,8 @@
                                 <jre.checkedMode>DISABLED</jre.checkedMode>
                                 <jre.checks.checkLevel>MINIMAL</jre.checks.checkLevel>
                                 <jsinterop.checks>DISABLED</jsinterop.checks>
-                                <!--
                                 <walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>EN-AU</walkingkooka.j2cl.java.util.locale.Locale.DEFAULT>
-                                -->
+                                <walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>Australia/Sydney</walkingkooka.j2cl.java.util.timezone.TimeZone.DEFAULT>
                             </defines>
                             <externs/>
                             <formatting>

--- a/src/it/junit-test/src/test/java/test/JunitTest.java
+++ b/src/it/junit-test/src/test/java/test/JunitTest.java
@@ -38,14 +38,8 @@ import java.util.stream.Collectors;
 
 
 @J2clTestInput(JunitTest.class)
-public class JunitTest {
-
-    @BeforeClass
-    public static void setDefaultLocale() {
-        Locale.setDefault(Locale.forLanguageTag("EN-AU"));
-        TimeZone.setDefault(TimeZone.getTimeZone("Australia/Sydney"));
-    }
-
+public final class JunitTest {
+    
     @Test
     public void testDateTimeFormatterFormatLocalDate() {
         this.formatAndCheck(DateTimeFormatter.ISO_LOCAL_DATE,


### PR DESCRIPTION
…0614

- https://github.com/mP1/j2cl-java-util-TimeZone/pull/80
- Default TimeZone system property

- https://github.com/mP1/j2cl-java-util-Locale/pull/129
- default Locale system property