### PR TITLE
jsr250-dependency removed 2

### DIFF
--- a/src/maven/pom.xml
+++ b/src/maven/pom.xml
@@ -170,12 +170,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>javax.annotation</groupId>
-            <artifactId>jsr250-api</artifactId>
-            <version>1.0</version>
-        </dependency>
-
-        <dependency>
             <groupId>walkingkooka</groupId>
             <artifactId>walkingkooka-text-printer</artifactId>
             <version>1.0-SNAPSHOT</version>


### PR DESCRIPTION
- Forgot to remove from the minimal POM thats included in the final jar.